### PR TITLE
Fix installation error due to metro-react-native-babel-preset not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "husky": "^4.2.5",
     "jest": "^25.3.0",
+    "metro-react-native-babel-preset": "^0.59.0",
     "prettier": "^1.19.1",
     "release-it": "^12.6.3",
     "typescript": "^3.7.5"


### PR DESCRIPTION
* This was removed from dependencies in 5a8ea8b8f7ddeb3873af9fdf60f6354733c4c178
* Add it back into devDependencies